### PR TITLE
Update installation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ It is also available as library. Full API Documentation is available on [https:/
 ```
 pip install pybeagle
 ```
+*Note: Only Python 3.6 is currently supported.*
+
+Rekall is not automatically installed. To install Rekall execute the following command instead:
+```
+pip install pybeagle[rekall]
+```
+
 
 ### Configuration
 


### PR DESCRIPTION
This PR updates the installation guidelines with the following changes: 

1. A note that only Python 3.6 is supported 
2. Installation steps for including Rekall